### PR TITLE
Add userID, directoryID and lastConnectionTime to the report

### DIFF
--- a/source/engine/lib/directory_reader.py
+++ b/source/engine/lib/directory_reader.py
@@ -1,5 +1,5 @@
-#!/usr/bin/python 
-# -*- coding: utf-8 -*- 
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 ######################################################################################################################
 #  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.                                           #
 #                                                                                                                    #
@@ -74,7 +74,7 @@ class DirectoryReader(object):
             return 0
 
         try: directoryParams['CSV']
-        except: wsCsv = 'WorkspaceID,DirectoryID,UserName,Billable Hours,Last Connection,Usage Threshold,Change Reported,Bundle Type,Initial Mode,New Mode\n'
+        except: wsCsv = 'WorkspaceID,DirectoryID,UserName,ComputerName,Billable Hours,Last Connection,Usage Threshold,Change Reported,Bundle Type,Initial Mode,New Mode\n'
         else: wsCsv = directoryParams['CSV']
 
         try: directoryParams['NextToken']
@@ -137,7 +137,7 @@ class DirectoryReader(object):
                     log.info('Sending solution tracking metrics to %s', url)
 
                     # added to overcome ssl certificate
-        
+
                     context = ssl._create_unverified_context()
                     req = urllib.request.Request(url, data=data, headers=headers)
                     rsp = urllib.request.urlopen(req, timeout=5, context=context)

--- a/source/engine/lib/directory_reader.py
+++ b/source/engine/lib/directory_reader.py
@@ -74,7 +74,7 @@ class DirectoryReader(object):
             return 0
 
         try: directoryParams['CSV']
-        except: wsCsv = 'WorkspaceID,Billable Hours,Usage Threshold,Change Reported,Bundle Type,Initial Mode,New Mode\n'
+        except: wsCsv = 'WorkspaceID,DirectoryID,UserName,Billable Hours,Usage Threshold,Change Reported,Bundle Type,Initial Mode,New Mode\n'
         else: wsCsv = directoryParams['CSV']
 
         try: directoryParams['NextToken']

--- a/source/engine/lib/directory_reader.py
+++ b/source/engine/lib/directory_reader.py
@@ -74,7 +74,7 @@ class DirectoryReader(object):
             return 0
 
         try: directoryParams['CSV']
-        except: wsCsv = 'WorkspaceID,DirectoryID,UserName,Billable Hours,Usage Threshold,Change Reported,Bundle Type,Initial Mode,New Mode\n'
+        except: wsCsv = 'WorkspaceID,DirectoryID,UserName,Billable Hours,Last Connection,Usage Threshold,Change Reported,Bundle Type,Initial Mode,New Mode\n'
         else: wsCsv = directoryParams['CSV']
 
         try: directoryParams['NextToken']

--- a/source/engine/lib/workspaces_helper.py
+++ b/source/engine/lib/workspaces_helper.py
@@ -56,6 +56,8 @@ class WorkspacesHelper(object):
         s = ','
         csv = oldCsv + s.join((
             result['workspaceID'],
+            result['directoryID'],
+            result['userName'],
             str(result['billableTime']),
             str(result['hourlyThreshold']),
             result['optimizationResult'],
@@ -119,6 +121,8 @@ class WorkspacesHelper(object):
 
         return {
             'workspaceID': workspaceID,
+            'directoryID': workspace['DirectoryId'],
+            'userName': workspace['UserName'],
             'billableTime': billableTime,
             'hourlyThreshold': hourlyThreshold,
             'optimizationResult': optimizationResult['resultCode'],

--- a/source/engine/lib/workspaces_helper.py
+++ b/source/engine/lib/workspaces_helper.py
@@ -59,6 +59,7 @@ class WorkspacesHelper(object):
             result['directoryID'],
             result['userName'],
             str(result['billableTime']),
+            str(result['lastConnectionTime']),
             str(result['hourlyThreshold']),
             result['optimizationResult'],
             result['bundleType'],
@@ -78,7 +79,10 @@ class WorkspacesHelper(object):
     '''
     returns {
         workspaceID: str,
+        directoryID: str,
+        userName: tr
         billableTime: int,
+        lastConnectionTime: datetime,
         hourlyThreshold: int,
         optimizationResult: str,
         initialMode: str,
@@ -102,6 +106,10 @@ class WorkspacesHelper(object):
             self.settings['endTime']
         );
 
+        lastConnectionTime = self.client.describe_workspaces_connection_status(
+            WorkspaceIds=[workspaceID]
+        )['WorkspacesConnectionStatus'][0]['LastKnownUserConnectionTimestamp']
+
         if self.check_for_skip_tag(workspaceID) == True:
             log.info('Skipping WorkSpace %s due to Skip_Convert tag', workspaceID)
             optimizationResult = {
@@ -124,6 +132,7 @@ class WorkspacesHelper(object):
             'directoryID': workspace['DirectoryId'],
             'userName': workspace['UserName'],
             'billableTime': billableTime,
+            'lastConnectionTime': lastConnectionTime,
             'hourlyThreshold': hourlyThreshold,
             'optimizationResult': optimizationResult['resultCode'],
             'newMode': optimizationResult['newMode'],

--- a/source/engine/lib/workspaces_helper.py
+++ b/source/engine/lib/workspaces_helper.py
@@ -59,7 +59,7 @@ class WorkspacesHelper(object):
             result['directoryID'],
             result['userName'],
             str(result['billableTime']),
-            str(result['lastConnectionTime']),
+            result['lastConnectionTime'],
             str(result['hourlyThreshold']),
             result['optimizationResult'],
             result['bundleType'],
@@ -80,9 +80,9 @@ class WorkspacesHelper(object):
     returns {
         workspaceID: str,
         directoryID: str,
-        userName: tr
+        userName: str
         billableTime: int,
-        lastConnectionTime: datetime,
+        lastConnectionTime: str,
         hourlyThreshold: int,
         optimizationResult: str,
         initialMode: str,
@@ -106,9 +106,13 @@ class WorkspacesHelper(object):
             self.settings['endTime']
         );
 
-        lastConnectionTime = self.client.describe_workspaces_connection_status(
+        lastKnownUserConnectionTimestamp = self.client.describe_workspaces_connection_status(
             WorkspaceIds=[workspaceID]
-        )['WorkspacesConnectionStatus'][0]['LastKnownUserConnectionTimestamp']
+        )['WorkspacesConnectionStatus'][0].get('LastKnownUserConnectionTimestamp')
+        if lastKnownUserConnectionTimestamp is None:
+            lastConnectionTime = 'Unavailable'
+        else:
+            lastConnectionTime = str(lastKnownUserConnectionTimestamp)
 
         if self.check_for_skip_tag(workspaceID) == True:
             log.info('Skipping WorkSpace %s due to Skip_Convert tag', workspaceID)

--- a/source/engine/lib/workspaces_helper.py
+++ b/source/engine/lib/workspaces_helper.py
@@ -1,5 +1,5 @@
-#!/usr/bin/python 
-# -*- coding: utf-8 -*- 
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 ######################################################################################################################
 #  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.                                           #
 #                                                                                                                    #
@@ -58,6 +58,7 @@ class WorkspacesHelper(object):
             result['workspaceID'],
             result['directoryID'],
             result['userName'],
+            result['computerName'],
             str(result['billableTime']),
             result['lastConnectionTime'],
             str(result['hourlyThreshold']),
@@ -81,6 +82,7 @@ class WorkspacesHelper(object):
         workspaceID: str,
         directoryID: str,
         userName: str
+        computerName: str
         billableTime: int,
         lastConnectionTime: str,
         hourlyThreshold: int,
@@ -135,6 +137,7 @@ class WorkspacesHelper(object):
             'workspaceID': workspaceID,
             'directoryID': workspace['DirectoryId'],
             'userName': workspace['UserName'],
+            'computerName': workspace['ComputerName'],
             'billableTime': billableTime,
             'lastConnectionTime': lastConnectionTime,
             'hourlyThreshold': hourlyThreshold,


### PR DESCRIPTION
*Issue #, if available:* #15

*Description of changes:* Adds user name, directory ID and when the user connected last to the report. Since the report is already there, these are useful for manual review. The downside is that it almost doubles the time it takes to run in this form. ECR image must be rebuilt in this case.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
