### PR TITLE
Remove the date_utils call to avoid incorrect termination of workspaces.

### DIFF
--- a/source/workspaces_app/workspaces_app/utils/__tests__/test_date_utils.py
+++ b/source/workspaces_app/workspaces_app/utils/__tests__/test_date_utils.py
@@ -69,3 +69,11 @@ def test_get_date_time_values_for_processing_returns_all_the_correct_values():
         "date_today": '11/29/20',
         "date_for_s3_key": '2020/11/29/'
     }
+
+
+@freeze_time("2020-05-31 23:00:00", auto_tick_seconds=86400)
+def test_get_first_day_selected_month_returns_first_day_selected_month_then_returns_next_month_date():
+    result = date_utils.get_first_day_selected_month()
+    assert result == datetime.date(2020, 5, 1)
+    result = date_utils.get_first_day_selected_month()
+    assert result == datetime.date(2020, 6, 1)

--- a/source/workspaces_app/workspaces_app/utils/workspace_utils.py
+++ b/source/workspaces_app/workspaces_app/utils/workspace_utils.py
@@ -5,7 +5,6 @@
 
 import logging
 import os
-from . import date_utils
 
 TERMINATE_UNUSED_WORKSPACES = os.getenv('TerminateUnusedWorkspaces')
 RESOURCE_UNAVAILABLE = 'ResourceUnavailable'
@@ -21,7 +20,7 @@ def is_terminate_workspace_enabled():
     return TERMINATE_UNUSED_WORKSPACES == "Yes" or TERMINATE_UNUSED_WORKSPACES == "Dry Run"
 
 
-def check_if_workspace_used_for_selected_period(last_known_user_connection_timestamp):
+def check_if_workspace_used_for_selected_period(last_known_user_connection_timestamp, first_day_selected_month):
     """
     This method returns a boolean value to indicate if the workspace was used in selected period
     :param: last_known_user_connection_timestamp: Last known connection timestamp
@@ -36,7 +35,6 @@ def check_if_workspace_used_for_selected_period(last_known_user_connection_times
         return True
     else:
         log.debug("Last know timestamp value is not None. Processing further.")
-        first_day_selected_month = date_utils.get_first_day_selected_month()
         log.debug(f'First day for selected period is {first_day_selected_month}')
         last_known_user_connection_day = last_known_user_connection_timestamp.date()
         return last_known_user_connection_day >= first_day_selected_month

--- a/source/workspaces_app/workspaces_app/workspaces_helper.py
+++ b/source/workspaces_app/workspaces_app/workspaces_helper.py
@@ -181,14 +181,15 @@ class WorkspacesHelper(object):
                     self.settings.get('dateTimeValues').get('current_month_last_day') or
                     (self.settings.get('testEndOfMonth'))
             ):
-                log.debug('Today is the last day of the month or the TestEndOfMonth parameter is set to yes.')
+                log.debug(f"The value for current_month_last_day is {self.settings.get('dateTimeValues').get('current_month_last_day')}")
+                log.debug(f"The value for testEndOfMonth is {(self.settings.get('testEndOfMonth'))}")
                 log.debug(f'Processing further for workspace id {workspace_id}')
                 last_known_user_connection_timestamp = self.get_last_known_user_connection_timestamp(workspace_id)
                 log.debug(f'Last known user connection time stamp is {last_known_user_connection_timestamp}')
                 workspace_available_on_first_day_of_selected_month = self.check_if_workspace_available_on_first_day_selected_month(workspace_id)
                 log.debug((f'The value for workspace available on first day of selected period is '
                            f'{workspace_available_on_first_day_of_selected_month}'))
-                workspace_used_in_selected_period = workspace_utils.check_if_workspace_used_for_selected_period(last_known_user_connection_timestamp)
+                workspace_used_in_selected_period = workspace_utils.check_if_workspace_used_for_selected_period(last_known_user_connection_timestamp, self.settings.get('dateTimeValues').get('first_day_selected_month'))
                 log.debug(f'The value for workspace used in selected period is {workspace_used_in_selected_period}')
                 if workspace_available_on_first_day_of_selected_month and not workspace_used_in_selected_period:
                     workspace_terminated = self.check_if_workspace_needs_to_be_terminated(workspace_id)


### PR DESCRIPTION
*Issue #, if available:*

The method call for date_utils can lead to workspace termination for tasks that might span for multiple days.

*Description of changes:*

Removed the method call for date_utils and added input parameter to the method to check for workspace usage.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
