### PR TITLE
release/v2.6.5

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,7 +22,7 @@ assignees: ""
 
 - [ ] Version: [e.g. v1.0.0]
 
-To get the version of the solution, you can look at the description of the created CloudFormation stack. For example, "_(SO0009) - The AWS CloudFormation template for deployment of the aws-centralized-logging. Version v1.0.0_". You can also find the version from [releases](https://github.com/aws-solutions/cost-optimizer-for-amazon-workspaces/releases)
+To get the version of the solution, you can look at the description of the created CloudFormation stack. For example, "_(SO0018) - The AWS CloudFormation template for deployment of the cost-optimizer-for-amazon-workspaces. Version v1.0.0_". You can also find the version from [releases](https://github.com/aws-solutions/cost-optimizer-for-amazon-workspaces/releases)
 
 - [ ] Region: [e.g. us-east-1]
 - [ ] Was the solution modified from the version published on this repository?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
  The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
  and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.5] - 2024-02
+### Fixed
+- Updated the base python image in the Dockerfile used to mitigate [CVE-2023-47038](https://security-tracker.debian.org/tracker/CVE-2023-47038).
+- Update pip to mitigate [CVE-2023-5752](https://nvd.nist.gov/vuln/detail/CVE-2023-5752).
+- Add dependency to route to mitigate race condition between internet gateway and the route to the internet gateway.
+
 ## [2.6.4] - 2023-10
  ### Fixed
  - Updated @babel/traverse to mitigate [CVE-2023-45133](https://github.com/aws-solutions/cost-optimizer-for-amazon-workspaces/pull/61)

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -31,6 +31,7 @@ boto3 under the Apache License 2.0
 attrs under the MIT License
 botocore under the Apache License 2.0
 certifi under the Mozilla Public License 2.0
+charset-normalizer under the MIT License
 idna under the BSD 3-Clause "New" or "Revised" License
 iniconfig under the MIT License
 jmespath under the MIT License
@@ -45,15 +46,8 @@ urllib3 under the MIT License
 freezegun under the Apache License Version 2.0
 pytest-cov under the MIT License
 pytest-env under the MIT License
-python-dateutil under the Apache License 2.0
-s3transfer under the Apache License 2.0
-six under the MIT License
 urllib3 under the MIT License
 virtualenv under the MIT License
 wheel under the MIT license
-wheel under the MIT license
 setuptools under the MIT license
-setuptools under the MIT license
-pip under the MIT license
-freezegun under the Apache License Version 2.0
 pip under the MIT license

--- a/README.md
+++ b/README.md
@@ -248,10 +248,10 @@ npm run synth
 <a name="collection-of-operational-metrics"></a>
 # Collection of operational metrics
 
-This solution collects anonymous operational metrics to help AWS improve the
+This solution collects anonymized operational metrics to help AWS improve the
 quality of features of the solution. For more information, including how to disable
 this capability, please see the
-[Implementation Guide](https://docs.aws.amazon.com/solutions/latest/cost-optimizer-for-workspaces/appendix.html)
+[Implementation Guide](https://docs.aws.amazon.com/solutions/latest/cost-optimizer-for-workspaces/anonymized-data-collection.html)
 
 <a name="license"></a>
 # License

--- a/source/Dockerfile
+++ b/source/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/python:3.11.6-slim-bullseye
+FROM public.ecr.aws/docker/library/python:3.12.2-slim-bookworm
 COPY workspaces_app /workspaces_app
 
 WORKDIR /workspaces_app

--- a/source/lib/components/vpc-resources.ts
+++ b/source/lib/components/vpc-resources.ts
@@ -118,6 +118,7 @@ export class VpcResources extends Construct {
             routeTableId: mainRouteTable.ref,
             gatewayId: internetGateway.ref
         })
+        routeToInternet.addDependency(internetGatewayAttachment)
         overrideLogicalId(routeToInternet, 'RouteToInternet')
 
         const subnet1RouteTableAssociation = new CfnSubnetRouteTableAssociation(this, 'Subnet1RouteTableAssociation', {

--- a/source/package-lock.json
+++ b/source/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cost-optimizer-for-amazon-workspaces",
-  "version": "2.6.3",
+  "version": "2.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cost-optimizer-for-amazon-workspaces",
-      "version": "2.6.3",
+      "version": "2.6.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-cdk/aws-servicecatalogappregistry-alpha": "^2.94.0-alpha.0",

--- a/source/package.json
+++ b/source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cost-optimizer-for-amazon-workspaces",
-  "version": "2.6.3",
+  "version": "2.6.5",
   "description": "Cost Optimizer for Amazon Workspaces (SO0018)",
   "license": "Apache-2.0",
   "repository": {
@@ -15,10 +15,10 @@
     "test": "jest --coverage",
     "license-report": "license-report --output=csv --delimiter=' under ' --fields=name --fields=licenseType",
     "cdk": "cdk",
-    "bootstrap": "SOLUTION_VERSION=v2.6.0 SOLUTION_NAME=cost-optimizer-for-amazon-workspaces SOLUTION_TRADEMARKEDNAME=cost-optimizer-for-amazon-workspaces cdk bootstrap",
-    "deploy": "SOLUTION_VERSION=v2.6.0 SOLUTION_NAME=cost-optimizer-for-amazon-workspaces SOLUTION_TRADEMARKEDNAME=cost-optimizer-for-amazon-workspaces cdk deploy cost-optimizer-for-amazon-workspaces",
-    "deploySpoke": "SOLUTION_VERSION=v2.6.0 SOLUTION_NAME=cost-optimizer-for-amazon-workspaces SOLUTION_TRADEMARKEDNAME=cost-optimizer-for-amazon-workspaces cdk deploy cost-optimizer-for-amazon-workspaces-spoke",
-    "synth": "SOLUTION_VERSION=v2.6.0 SOLUTION_NAME=cost-optimizer-for-amazon-workspaces SOLUTION_TRADEMARKEDNAME=cost-optimizer-for-amazon-workspaces DIST_OUTPUT_BUCKET=solutions-reference cdk synth"
+    "bootstrap": "SOLUTION_VERSION=v2.6.5 SOLUTION_NAME=cost-optimizer-for-amazon-workspaces SOLUTION_TRADEMARKEDNAME=cost-optimizer-for-amazon-workspaces cdk bootstrap",
+    "deploy": "SOLUTION_VERSION=v2.6.5 SOLUTION_NAME=cost-optimizer-for-amazon-workspaces SOLUTION_TRADEMARKEDNAME=cost-optimizer-for-amazon-workspaces cdk deploy cost-optimizer-for-amazon-workspaces",
+    "deploySpoke": "SOLUTION_VERSION=v2.6.5 SOLUTION_NAME=cost-optimizer-for-amazon-workspaces SOLUTION_TRADEMARKEDNAME=cost-optimizer-for-amazon-workspaces cdk deploy cost-optimizer-for-amazon-workspaces-spoke",
+    "synth": "SOLUTION_VERSION=v2.6.5 SOLUTION_NAME=cost-optimizer-for-amazon-workspaces SOLUTION_TRADEMARKEDNAME=cost-optimizer-for-amazon-workspaces DIST_OUTPUT_BUCKET=solutions-reference cdk synth"
   },
   "devDependencies": {
     "@aws-cdk/assert": "2.68.0",

--- a/source/test/__snapshots__/hub-snapshot.test.ts.snap
+++ b/source/test/__snapshots__/hub-snapshot.test.ts.snap
@@ -1944,6 +1944,9 @@ exports[`hub stack synth matches the existing snapshot 1`] = `
     },
     "RouteToInternet": {
       "Condition": "CreateNewVPCCondition",
+      "DependsOn": [
+        "InternetGatewayAttachment",
+      ],
       "Properties": {
         "DestinationCidrBlock": "0.0.0.0/0",
         "GatewayId": {

--- a/source/testing_requirements.txt
+++ b/source/testing_requirements.txt
@@ -1,4 +1,3 @@
-uuid==1.30
 pytest>=7.2.0
 pytest-mock==3.10.0
 coverage==7.2.0

--- a/source/workspaces_app/setup_requirements.txt
+++ b/source/workspaces_app/setup_requirements.txt
@@ -1,2 +1,2 @@
-pip==22.2.2
+pip==24.0
 setuptools==68.2.0


### PR DESCRIPTION
*Issue #, if available:*
Update to v2.6.5

*Description of changes:*
## [2.6.5] - 2024-02
### Fixed
- Updated the base python image in the Dockerfile used to mitigate [CVE-2023-47038](https://security-tracker.debian.org/tracker/CVE-2023-47038).
- Update pip to mitigate [CVE-2023-5752](https://nvd.nist.gov/vuln/detail/CVE-2023-5752).
- Add dependency to route to mitigate race condition between internet gateway and the route to the internet gateway.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
